### PR TITLE
Fix ChoiceView

### DIFF
--- a/js/foam/ui/ChoiceView.js
+++ b/js/foam/ui/ChoiceView.js
@@ -89,7 +89,7 @@ this.on('mouseout', this.onMouseOut))) %>" <% if ( choice[0] === this.data ) { %
     {
       name: 'onClick',
       code: function(e) {
-        this.data = this.prev = this.choices[e.target.value][0];
+        this.data = this.prev = this.choices[this.index][0];
       }
     }
   ]


### PR DESCRIPTION
ChoiceViews with size>1 did not select the item in the list when clicked and instead defaulted to the first item in the list. Fixed to set the selected choice correctly.